### PR TITLE
Add Gruvbox themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ Following data attributes are available to customize the postcard.
 
 #### available themes
 
-| No. | theme-name     | reference                 |
-| --- | -------------- | ------------------------- |
-| 1   | default        | https://hashnode.com      |
-| 2   | devto          | https://dev.to            |
-| 3   | hashnode-light | https://hashnode.com      |
-| 4   | dracula        | https://draculatheme.com  |
-| 5   | nord-light     | https://www.nordtheme.com |
-| 6   | nord-dark      | https://www.nordtheme.com |
+| No. | theme-name     | reference                          |
+| --- | -------------- | ---------------------------------- |
+| 1   | default        | https://hashnode.com               |
+| 2   | devto          | https://dev.to                     |
+| 3   | hashnode-light | https://hashnode.com               |
+| 4   | dracula        | https://draculatheme.com           |
+| 5   | nord-light     | https://www.nordtheme.com          |
+| 6   | nord-dark      | https://www.nordtheme.com          |
+| 7   | gruvbox-light  | https://github.com/morhetz/gruvbox |
+| 8   | gruvbox-dark   | https://github.com/morhetz/gruvbox |

--- a/src/themes.js
+++ b/src/themes.js
@@ -59,6 +59,26 @@ const THEMES = {
       secondary: "#D8DEE9",
     },
   },
+  "gruvbox-light": {
+    background: {
+      primary: "#FBF1C7",
+      secondary: "#EBDBB2",
+    },
+    foreground: {
+      primary: "#B57614",
+      secondary: "#3C3836",
+    },
+  },
+  "gruvbox-dark": {
+    background: {
+      primary: "#282828",
+      secondary: "#3C3836",
+    },
+    foreground: {
+      primary: "#FABD2F",
+      secondary: "#EBDBB2",
+    },
+  }
 };
 
 export default THEMES;


### PR DESCRIPTION
For #2 

Added **Gruvbox** light and dark themes.

Light:

![Screenshot 2023-10-15 143330](https://github.com/AyushSaini00/hashnode-postcard/assets/66974007/e4a0e8e3-596f-48b9-b256-963ea5c820e9)

Dark:


![Screenshot 2023-10-15 143404](https://github.com/AyushSaini00/hashnode-postcard/assets/66974007/fa55501b-0f29-4a2a-afeb-c1d0f40e00e6)
